### PR TITLE
R/20191216 add details for checkboxes

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,18 +2,24 @@
 <!-- [PROJECT-NNN] Fixes an issue where ... -->
 <!-- This should connect your PR to the appropriate JIRA ticket -->
 
-<!-- Please update the link below with the Jira project and issue number. -->
+<!-- Please update the following with your Jira project and issue number. -->
+# [PROJECT-NNN] Ticket Title / Description
 
-[PROJECT-NNN](https://lambdaschool.atlassian.net/browse/PROJECT-NNN) Ticket Title / Description
+Type of change: [CHANGE TYPE HERE]
+<!-- Use one of the following or add your own
+
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- This change requires a documentation update
+-->
 
 ## Description
 <!-- Please include a summary of the change, motivation, and context. -->
 
 
-## Type of change
-<!-- Place an `x` in between the corresponding `[ ]` without a space `[x]` -->
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [x] This change requires a documentation update
+## Launch Checklist
+<!-- If you know you need to do additional things to get this live
+like update the changelog, you can add them as a checklist here.-->
+- [x] Start Launch checklist
+- [ ] Empty checkbox to remind me to do something

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,19 @@
-<!-- Please prefix the subject above with the Jira issue number. Example: -->
-<!-- [CORE-XYZ] Fixes an issue where ... -->
+<!-- /\ Please prefix the subject above with the Jira issue number. Example: -->
+<!-- [PROJECT-NNN] Fixes an issue where ... -->
+<!-- This should connect your PR to the appropriate JIRA ticket -->
 
-## Jira Issue
-<!-- Please update the link below with the Jira issue number. -->
+<!-- Please update the link below with the Jira project and issue number. -->
 
-[CORE-]
+[PROJECT-NNN](https://lambdaschool.atlassian.net/browse/PROJECT-NNN) Ticket Title / Description
 
 ## Description
 <!-- Please include a summary of the change, motivation, and context. -->
 
 
-
 ## Type of change
-<!-- Place an `x` in between the corresponding `[ ]`. -->
+<!-- Place an `x` in between the corresponding `[ ]` without a space `[x]` -->
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
+- [x] This change requires a documentation update


### PR DESCRIPTION
[OUTCOMES-241]

I'd like to propose an overhaul of this template that will 
- include a link to the JIRA ticket for easy access,
- remove the checkboxes for the type of the change. The checkbox shows up in the PR summary as things to do
- add checkboxes for reminders of things to do -- their intended use

Todo
- [ ] Solicit feedback on this proposal

Example using this new template
https://github.com/LambdaSchoolEngineering/dashboards/pull/421

See the checkbox checklist on the PR
<img width="538" alt="Screen Shot 2020-03-06 at 11 48 11 AM" src="https://user-images.githubusercontent.com/151852/76117317-732daa00-5fa0-11ea-8c25-614e86b8d6e4.png">


[OUTCOMES-241]: https://lambdaschool.atlassian.net/browse/OUTCOMES-241