### PR TITLE
Fix exclude label to ignore-from-release-notes

### DIFF
--- a/release.yml
+++ b/release.yml
@@ -1,7 +1,7 @@
 changelog:
   exclude:
     labels:
-      - ignore-for-release-notes
+      - ignore-from-release-notes
   categories:
     - title: New Features 🎉
       labels:

--- a/release.yml
+++ b/release.yml
@@ -2,6 +2,9 @@ changelog:
   exclude:
     labels:
       - ignore-from-release-notes
+     authors:
+      - ls-api-user
+      - dependabot
   categories:
     - title: New Features 🎉
       labels:


### PR DESCRIPTION
## Description
- ignore-for-release-notes --> ignore-from-release-notes
- Add ignore PRs from author ls-api-user (Remove Deploy to Production) and dependabot


## Additional Resources
- Link to Jira: N/A
- Link to documentation, if any: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes


## How Has This Been Tested?
- This is a release.yml config change, functionality is not affected by this change.

#### Type of Test Done: <!-- Delete the ones that do not apply -->
- Manual

## Checklist
- [x] I have added a GitHub label for the type of change (Bug Fix, New Feature, Breaking Change, Refactor).
- [x] I have added the Jira ticket number at the beginning of the PR's title
- [x] I have confirmed that all tests pass.
- [x] I have performed a self-review of my own code.
- [x] I can't think of any additional scenarios to test.
